### PR TITLE
remove EXAMPLE, unnecessary lines

### DIFF
--- a/includes/z_setup.Rmd
+++ b/includes/z_setup.Rmd
@@ -18,17 +18,6 @@ library(tidyverse)
 library(devtools)
 library(googleVis)
 
-# Load the client ID, client secret, and GA view ID
-client_id <- Sys.getenv("GA_CLIENT_ID")
-client_secret <- Sys.getenv("GA_CLIENT_SECRET")
-
-# Set the client ID and client secret as options for googleAuthR
-options(googleAuthR.client_id = client_id)
-options(googleAuthR.client_secret = client_secret)
-
-# Reload the googleAnalyticsR package so those options get set in googleAuthR
-devtools::reload(pkg = devtools::inst("googleAnalyticsR"))
-
 # Authorize GA. Depending on if you've done this already and a .httr-oauth file has
 # been saved or not, this may pop you over to a browser to authenticate.
 ga_auth()

--- a/setup.Rmd
+++ b/setup.Rmd
@@ -29,12 +29,12 @@ No, silly, you don't want a bunch of Xs there! You will need to update those wit
 
 * **GA_CLIENT_ID** -- this is just the client ID from the Google Project you created following Donal's instructions
 * **GA_CLIENT_SECRET** -- it's not secret to you! This is just the client secret you created at the same time you created the client ID
-* **GA_EXAMPLE_VIEW_ID** -- this is the view ID that you want to use (at least initially) for exploring the examples. You can go to the [Google Analytics Query Explorer](https://ga-dev-tools.appspot.com/query-explorer/), select an account, property, and view, and then grab this value -- it's the `ids` value that is the first field under the *Query Parameters* section
+* **GA_VIEW_ID** -- this is the view ID that you want to use (at least initially) for exploring the examples. You can go to the [Google Analytics Query Explorer](https://ga-dev-tools.appspot.com/query-explorer/), select an account, property, and view, and then grab this value -- it's the `ids` value that is the first field under the *Query Parameters* section
 
 Now, save the file.
 
 ## 3. Reload the .Renviron file
-This happens any time you start a new R session, so you won't have to worry about this going forward unless you change a value (like `GA_EXAMPLE_VIEW_ID`). For this one time, though, select **Session > Restart R** in RStudio.
+This happens any time you start a new R session, so you won't have to worry about this going forward unless you change a value (like `GA_VIEW_ID`). For this one time, though, select **Session > Restart R** in RStudio.
 
 ## 4. Confirm that your .Renviron file is working
 Run the following code in your console:


### PR DESCRIPTION
The view ID is specified in the examples such as [here](http://www.dartistics.com/googleanalytics/simple-medium-ordered-by-sessions.html) use `GA_VIEW_ID` put the setup page uses `GA_EXAMPLE_VIEW_ID`

Also took out unnecessary client setup if they are using the `.Renviron`